### PR TITLE
Fix skip_whitespaces() segfault

### DIFF
--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -67,7 +67,16 @@ void skip_whitespaces(void) {
 		} else if (isspace(*input)) {
 			input++;
 		} else if (*input == ';' || (*input == '/' && *(input+1) == '/')) {
-			input = strchr(input, '\n');
+			char* input_test = strchr(input, '\n');
+			if (!input_test) {
+				// No newline at end of file.
+				input_test = strchr(input, '\0');
+				if (!input_test)
+					error_at(input, "cannot find null terminator");
+				input = input_test;
+			} else {
+				input = input_test;
+			}
 		} else if (*input == '/' && *(input+1) == '*') {
 			const char* top = input;
 			do {


### PR DESCRIPTION
This fixes a segfault issue I encountered when experimenting with xsys35c. I was able to find the cause of it with the help of `gdb` backtrace.

When the last line of an ADV file is a comment and there's no newline at the end of file, `input` would be set to `NULL` by `strchr()` which leads to a null pointer dereference, causing the compiler to segfault.

Example code that would segfault:
```
'Testing'
A
; Comment at the last line.
```

After this change the same code compiles without issue. I've ran `regression_test.sh` and everything looks fine here, no apparent breakage.

Should note that the VSCode extension (as of 0.4.0) would not abort or show warnings in case the compiler segfaulted. The only apparent phenomenon would be that `xsystem35` is still running the old code -- changes you've just made are not applied.